### PR TITLE
Fix or remove broken exports that interfere with Embroider builds

### DIFF
--- a/app/mirage-serializers/json-api-serializer.js
+++ b/app/mirage-serializers/json-api-serializer.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-mirage-sauce/mirage-serializers/sauce-serializer';
+export { default } from 'ember-mirage-sauce/mirage-serializers/json-api-serializer';

--- a/app/serializers/foo.js
+++ b/app/serializers/foo.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-mirage-sauce/serializers/foo';


### PR DESCRIPTION
First, thanks for this addon, it has helped quite a bit with the Mirage config for the JSON:API-based backend in the app I work on :)

I am early on in the process of ensuring that our front-end app, which currently uses `ember-mirage-sauce`, will be eventually compatible with Ember's forthcoming [Embroider](https://github.com/embroider-build/embroider) build pipeline.

Currently, any attempt to build our Ember app using Embroider, with `ember-mirage-sauce` installed, will result in errors similar to the following:

```
ERROR in ../rewritten-packages/ember-mirage-sauce.39ab8789/node_modules/ember-mirage-sauce/_app_/mirage-serializers/json-api-serializer.js 1:0-81
Module not found: Error: Can't resolve './mirage-serializers/sauce-serializer' in '<local-app-path>/node_modules/.embroider/rewritten-packages/ember-mirage-sauce.39ab8789/node_modules/ember-mirage-sauce'
 @ ./assets/<app-name>.js 1732:13-75

ERROR in ../rewritten-packages/ember-mirage-sauce.39ab8789/node_modules/ember-mirage-sauce/_app_/serializers/foo.js 1:0-61
Module not found: Error: Can't resolve './serializers/foo' in '<local-app-path>/node_modules/.embroider/rewritten-packages/ember-mirage-sauce.39ab8789/node_modules/ember-mirage-sauce'
 @ ./assets/<app-name>.js 1735:13-52
```

These two errors are due to the following
1. app/mirage-serializers/json-api-serializer.js attempts to re-export a non-existent `sauce-serializer` file (presumably it should be re-exporting the `json-api-serializer` under the addon folder)
2. app/serializers/foo.js similarly attempts to re-export a non-existent `foo` serializer (it is not immediately clear what would have been intended, maybe just something missed in an earlier cleanup?)

This PR fixes app/mirage-serializers/json-api-serializer.js and removes app/serializers/foo.js to prevent these errors. 

**Testing:** I don't foresee these changes causing any functionality issues. However, tests are not running properly on either `master` or this branch due to a conflict in `ember-auto-import` versions apparently introduced by #36. Attempting to update the e-auto-import version in the package.json just leads to other dependency conflicts, which probably should be resolved through a fuller addon blueprint update beyond the scope of my current issue.

For now, I used `npm link` to install it in my app to confirm that 
- these specific ember-mirage-sauce errors no longer appeared when attempting an Embroider build (there are issues with other add-ons we still need to investigate), and 
- in our regular non-Embroider build, our tests that use mirage-sauce still work as expected.